### PR TITLE
Don't hardcode compiler to fix cross compilation.

### DIFF
--- a/config/common.mak.in
+++ b/config/common.mak.in
@@ -46,6 +46,8 @@ OGDI_VERSION      = $(OGDI_MAJOR)$(OGDI_MINOR)
 # Default definitions
 #
 
+AUTOCONF_CC = @CC@
+
 ifndef CFG
 CFG = release
 endif

--- a/config/unix.mak
+++ b/config/unix.mak
@@ -22,9 +22,9 @@ UNIX_DEFINE	= -Dunix
 #
 # Standard tools
 #
-CC		= gcc
-LD		= gcc
-SHLIB_LD	= gcc
+CC		= ${AUTOCONF_CC}
+LD		= ${AUTOCONF_CC}
+SHLIB_LD	= ${AUTOCONF_CC}
 AR		= ar cr
 RM		= rm
 RMALL		= rm -rf


### PR DESCRIPTION
As reported by Helmut Grohne in [Debian Bug #902033](https://bugs.debian.org/902033):
> ogdi-dfsg fails to cross build from source, because it does not
> propagate the correctly detected cross compiler from ./configure to
> make, but rather hard codes gcc. The attached patch fixes that and makes
> ogdi-dfsg cross build successfully. Please consider applying it.