### PR TITLE
Fix spelling errors.

### DIFF
--- a/ogdi/c-api/server.c
+++ b/ogdi/c-api/server.c
@@ -292,7 +292,7 @@ ecs_Result *svr_CreateServer(s,url,isLocal)
   res = s->createserver(s,url); 
   if (res == NULL) {
     res = &svr_dummy_result;
-    sprintf(buffer,"A memory error occured when creating the server for the URL \"%s\"", url);
+    sprintf(buffer,"A memory error occurred when creating the server for the URL \"%s\"", url);
     ecs_SetError(res,1,buffer);
     return res;
     }


### PR DESCRIPTION
The lintian QA tool reported a spelling error for the Debian package build:

 * occured -> occurred