### PR TITLE
contrib/gdal: Fix C99 compatibility issue

### DIFF
--- a/contrib/gdal/gdalbridge.c
+++ b/contrib/gdal/gdalbridge.c
@@ -71,6 +71,7 @@
 #include "gdalbridge.h"
 #include <stdio.h>
 #include <stdlib.h>
+#include <string.h>
 
 #ifdef _WIN32
 #define PATH_SEP '\\'


### PR DESCRIPTION
Include <string.h> for the strcpy function.  Future compilers will not support implicit function declarations by default, leading to a build failure.

Related to:

* https://fedoraproject.org/wiki/Changes/PortingToModernC
* https://fedoraproject.org/wiki/Toolchain/PortingToModernC
