### PR TITLE
Use time_t instead of long for variables passed to time().

### DIFF
--- a/ogdi/gltpd/asyncsvr.c
+++ b/ogdi/gltpd/asyncsvr.c
@@ -80,7 +80,7 @@ ECS_CVSID("$Id$");
 
 #define COMTIMEOUT 900
 
-long timecount;
+time_t timecount;
 
 static void dispatchno_1();
 extern void ecsprog_1();
@@ -533,7 +533,7 @@ void gltpd_svc_run()
   struct timeval timeout;
   xdrproc_t xdr_argument;
   /*xdrproc_t xdr_result;*/
-  long currenttime;
+  time_t currenttime;
   
   timeout.tv_sec = COMTIMEOUT;
   timeout.tv_usec = 0;


### PR DESCRIPTION
Fixes build failure on 32-bit systems with 64-bit time_t:
```
../asyncsvr.c: In function ‘gltpd_svc_run’:
../asyncsvr.c:553:14: error: passing argument 1 of ‘time’ from incompatible pointer type [-Wincompatible-pointer-types]
  553 |         time(&currenttime);
      |              ^~~~~~~~~~~~
      |              |
      |              long int *
In file included from /usr/include/features.h:510,
                 from /usr/include/powerpc-linux-gnu/sys/types.h:25,
                 from /usr/include/tirpc/rpc/types.h:41,
                 from /usr/include/tirpc/rpc/rpc.h:38,
                 from /<<PKGBUILDDIR>>/ogdi/include/ecs.h:9,
                 from ../asyncsvr.c:51:
/usr/include/time.h:85:15: note: expected ‘time_t *’ {aka ‘long long int *’} but argument is of type ‘long int *’
   85 | extern time_t __REDIRECT_NTH (time, (time_t *__timer), __time64);
      |               ^~~~~~~~~~~~~~
../asyncsvr.c:574:12: error: passing argument 1 of ‘time’ from incompatible pointer type [-Wincompatible-pointer-types]
  574 |       time(&timecount);
      |            ^~~~~~~~~~
      |            |
      |            long int *
/usr/include/time.h:85:15: note: expected ‘time_t *’ {aka ‘long long int *’} but argument is of type ‘long int *’
   85 | extern time_t __REDIRECT_NTH (time, (time_t *__timer), __time64);
      |               ^~~~~~~~~~~~~~
```
[armhf](https://buildd.debian.org/status/fetch.php?pkg=ogdi-dfsg&arch=armhf&ver=4.1.1%2Bds-4%2Bb1&stamp=1730245137&raw=0), [powerpc](https://buildd.debian.org/status/fetch.php?pkg=ogdi-dfsg&arch=powerpc&ver=4.1.1%2Bds-4%2Bb1&stamp=1730243254&raw=0), [x32](https://buildd.debian.org/status/fetch.php?pkg=ogdi-dfsg&arch=x32&ver=4.1.1%2Bds-4%2Bb1&stamp=1730218767&raw=0)